### PR TITLE
♻️ Rename Add-on to App and adopt the app workflows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,5 +25,5 @@ Even better: You could submit a pull request with a fix / new feature!
    developers, or if you do not have permission to do that, you may request
    the second reviewer to merge it for you.
 
-[github]: https://github.com/timmo001/addon-thelounge/issues
-[prs]: https://github.com/timmo001/addon-thelounge/pulls
+[github]: https://github.com/hassio-addons/app-thelounge/issues
+[prs]: https://github.com/hassio-addons/app-thelounge/pulls

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -7,7 +7,7 @@ your contributions.
 ## Supported Versions
 
 Security updates are provided only for the latest released version of this
-add-on. Users are strongly encouraged to keep their installations up to date.
+app. Users are strongly encouraged to keep their installations up to date.
 
 | Version        | Supported          |
 | -------------- | ------------------ |
@@ -22,7 +22,7 @@ discussions, or pull requests.**
 Instead, report them privately through GitHub's private vulnerability
 reporting:
 
-[**Report a vulnerability**](https://github.com/hassio-addons/addon-thelounge/security/advisories/new)
+[**Report a vulnerability**](https://github.com/hassio-addons/app-thelounge/security/advisories/new)
 
 If for any reason you are unable to use GitHub's private vulnerability
 reporting, you may also reach out to the maintainer by email at
@@ -32,7 +32,7 @@ When reporting, please include as much of the following as possible:
 
 - A clear description of the vulnerability and its potential impact.
 - Steps to reproduce, or a proof of concept.
-- Affected version(s) of the add-on.
+- Affected version(s) of the app.
 - Any known mitigations or workarounds.
 
 ## Disclosure Timeline
@@ -61,10 +61,10 @@ The following are **not** considered security vulnerabilities in this project:
 - Issues in the Home Assistant Supervisor or Operating System; please report
   those directly to the
   [Home Assistant project](https://github.com/home-assistant/core/security/policy).
-- Exposure of the add-on to untrusted networks as a result of the user's own
+- Exposure of the app to untrusted networks as a result of the user's own
   configuration, such as publishing the direct port without SSL.
 
 ## Scope
 
-This security policy covers The Lounge Home Assistant add-on published from
+This security policy covers The Lounge Home Assistant app published from
 this repository, including its container images and configuration.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,11 +44,11 @@
       "automerge": true
     },
     {
-      "groupName": "Add-on base image",
+      "groupName": "App base image",
       "matchDatasources": ["docker"]
     },
     {
-      "groupName": "Add-on base image",
+      "groupName": "App base image",
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/addon-ci.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0
+    uses: hassio-addons/workflows/.github/workflows/app-ci.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,13 +19,13 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    uses: hassio-addons/workflows/.github/workflows/addon-ci.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0
+    uses: hassio-addons/workflows/.github/workflows/app-ci.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0
 
   deploy:
     needs: ci
     permissions:
       contents: read
       packages: write
-    uses: hassio-addons/workflows/.github/workflows/addon-deploy.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0
+    uses: hassio-addons/workflows/.github/workflows/app-deploy.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0
     secrets:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 
 [![GitHub Release][releases-shield]][releases]
 ![Project Stage][project-stage-shield]
@@ -18,7 +18,7 @@ A self-hosted web IRC client that uses a modern and sleek interface with
 support for theming, push notifications, link previews, file uploads and
 more. Fully cross-platform and mobile friendly.
 
-[:books: Read the full add-on documentation][docs]
+[:books: Read the full app documentation][docs]
 
 ![Screenshot][screenshot]
 
@@ -28,7 +28,7 @@ Got questions?
 
 You have several options to get them answered:
 
-- The [Home Assistant Community Add-ons Discord chat server][discord] for add-on
+- The [Home Assistant Community Apps Discord chat server][discord] for app
   support and feature requests.
 - The [Home Assistant Discord chat server][discord-ha] for general Home
   Assistant discussions and questions.
@@ -54,11 +54,11 @@ The original setup of this repository is by [Timmo][timmo].
 For a full list of all authors and contributors,
 check [the contributor's page][contributors].
 
-## We have got some Home Assistant add-ons for you
+## We have got some Home Assistant apps for you
 
 Want some more functionality to your Home Assistant instance?
 
-We have created multiple add-ons for Home Assistant. For a full list, check out
+We have created multiple apps for Home Assistant. For a full list, check out
 our [GitHub Repository][repository].
 
 ## License
@@ -87,22 +87,22 @@ SOFTWARE.
 
 [buymeacoffee-shield]: https://www.buymeacoffee.com/assets/img/guidelines/download-assets-sm-2.svg
 [buymeacoffee]: https://www.buymeacoffee.com/timmo
-[commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-thelounge.svg
-[commits]: https://github.com/hassio-addons/addon-thelounge/commits/main
-[contributors]: https://github.com/hassio-addons/addon-thelounge/graphs/contributors
+[commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/app-thelounge.svg
+[commits]: https://github.com/hassio-addons/app-thelounge/commits/main
+[contributors]: https://github.com/hassio-addons/app-thelounge/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
-[docs]: https://github.com/hassio-addons/addon-thelounge/blob/main/thelounge/DOCS.md
+[docs]: https://github.com/hassio-addons/app-thelounge/blob/main/thelounge/DOCS.md
 [forum]: https://community.home-assistant.io/?u=timmo001
-[github-actions-shield]: https://github.com/hassio-addons/addon-thelounge/workflows/CI/badge.svg
-[github-actions]: https://github.com/hassio-addons/addon-thelounge/actions
-[issue]: https://github.com/hassio-addons/addon-thelounge/issues
-[license-shield]: https://img.shields.io/github/license/hassio-addons/addon-thelounge.svg
+[github-actions-shield]: https://github.com/hassio-addons/app-thelounge/workflows/CI/badge.svg
+[github-actions]: https://github.com/hassio-addons/app-thelounge/actions
+[issue]: https://github.com/hassio-addons/app-thelounge/issues
+[license-shield]: https://img.shields.io/github/license/hassio-addons/app-thelounge.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
 [reddit]: https://reddit.com/r/homeassistant
-[releases-shield]: https://img.shields.io/github/release/hassio-addons/addon-thelounge.svg
-[releases]: https://github.com/hassio-addons/addon-thelounge/releases
+[releases-shield]: https://img.shields.io/github/release/hassio-addons/app-thelounge.svg
+[releases]: https://github.com/hassio-addons/app-thelounge/releases
 [repository]: https://github.com/hassio-addons/repository
-[screenshot]: https://raw.githubusercontent.com/hassio-addons/addon-thelounge/main/images/screenshot.png
+[screenshot]: https://raw.githubusercontent.com/hassio-addons/app-thelounge/main/images/screenshot.png
 [timmo]: https://github.com/timmo001

--- a/thelounge/.README.j2
+++ b/thelounge/.README.j2
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 
 [![Release][release-shield]][release] ![Project Stage][project-stage-shield] ![Project Maintenance][maintenance-shield]
 
@@ -17,8 +17,8 @@ A self-hosted web IRC client that uses a modern and sleek interface with
 {% if channel == "edge" %}
 ## WARNING! THIS IS AN EDGE VERSION!
 
-This Home Assistant Add-ons repository contains edge builds of add-ons.
-Edge builds add-ons are based upon the latest development version.
+This Home Assistant Apps repository contains edge builds of apps.
+Edge builds apps are based upon the latest development version.
 
 - They may not work at all.
 - They might stop working at any time.
@@ -27,10 +27,10 @@ Edge builds add-ons are based upon the latest development version.
 This repository was created for:
 
 - Anybody willing to test.
-- Anybody interested in trying out upcoming add-ons or add-on features.
+- Anybody interested in trying out upcoming apps or app features.
 - Developers.
 
-If you are more interested in stable releases of our add-ons:
+If you are more interested in stable releases of our apps:
 
 <https://github.com/hassio-addons/repository>
 
@@ -38,7 +38,7 @@ If you are more interested in stable releases of our add-ons:
 {% if channel == "beta" %}
 ## WARNING! THIS IS A BETA VERSION!
 
-This Home Assistant Add-ons repository contains beta releases of add-ons.
+This Home Assistant Apps repository contains beta releases of apps.
 
 - They might stop working at any time.
 - They could have a negative impact on your system.
@@ -46,9 +46,9 @@ This Home Assistant Add-ons repository contains beta releases of add-ons.
 This repository was created for:
 
 - Anybody willing to test.
-- Anybody interested in trying out upcoming add-ons or add-on features.
+- Anybody interested in trying out upcoming apps or app features.
 
-If you are more interested in stable releases of our add-ons:
+If you are more interested in stable releases of our apps:
 
 <https://github.com/hassio-addons/repository>
 
@@ -64,5 +64,5 @@ If you are more interested in stable releases of our add-ons:
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
 [release-shield]: https://img.shields.io/badge/version-{{ version }}-blue.svg
 [release]: {{ repo }}/tree/{{ version }}
-[screenshot]: https://raw.githubusercontent.com/hassio-addons/addon-thelounge/master/images/screenshot.png
+[screenshot]: https://raw.githubusercontent.com/hassio-addons/app-thelounge/main/images/screenshot.png
 [thelounge]: https://github.com/timmo001/thelounge

--- a/thelounge/DOCS.md
+++ b/thelounge/DOCS.md
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 
 A self-hosted web IRC client that uses a modern and sleek interface with
 support for theming, push notifications, link previews, file uploads and
@@ -6,25 +6,25 @@ more. Fully cross-platform and mobile friendly.
 
 ## Installation
 
-The installation of this add-on is pretty straightforward and not different in
-comparison to installing any other Home Assistant add-on.
+The installation of this app is pretty straightforward and not different in
+comparison to installing any other Home Assistant app.
 
-1. Click the Home Assistant My button below to open the add-on on your Home
+1. Click the Home Assistant My button below to open the app on your Home
    Assistant instance.
 
-   [![Open this add-on in your Home Assistant instance.][addon-badge]][addon]
+   [![Open this app in your Home Assistant instance.][addon-badge]][addon]
 
-1. Click the "Install" button to install the add-on.
-1. Configure the "The Lounge" add-on. (See below)
-1. Start the "The Lounge" add-on.
-1. Check the logs of the "The Lounge" add-on to see it in action.
+1. Click the "Install" button to install the app.
+1. Configure the "The Lounge" app. (See below)
+1. Start the "The Lounge" app.
+1. Check the logs of the "The Lounge" app to see it in action.
 1. Click "Open Web UI".
 
 ## Configuration
 
-**Note**: _Remember to restart the add-on when the configuration is changed._
+**Note**: _Remember to restart the app when the configuration is changed._
 
-Example add-on configuration:
+Example app configuration:
 
 ```yaml
 log_level: info
@@ -40,7 +40,7 @@ users:
 
 ### Option: `log_level`
 
-The `log_level` option controls the level of log output by the addon and can
+The `log_level` option controls the level of log output by the app and can
 be changed to be more or less verbose, which might be useful when you are
 dealing with an unknown issue. Possible values are:
 
@@ -49,7 +49,7 @@ dealing with an unknown issue. Possible values are:
 - `info`: Normal (usually) interesting events.
 - `warning`: Exceptional occurrences that are not errors.
 - `error`: Runtime errors that do not require immediate action.
-- `fatal`: Something went terribly wrong. Add-on becomes unusable.
+- `fatal`: Something went terribly wrong. App becomes unusable.
 
 Please note that each level automatically includes log messages from a
 more severe level, e.g., `debug` also shows `info` messages. By default,
@@ -109,7 +109,7 @@ Got questions?
 
 You have several options to get them answered:
 
-- The [Home Assistant Community Add-ons Discord chat server][discord] for add-on
+- The [Home Assistant Community Apps Discord chat server][discord] for app
   support and feature requests.
 - The [Home Assistant Discord chat server][discord-ha] for general Home
   Assistant discussions and questions.
@@ -151,13 +151,13 @@ SOFTWARE.
 
 [addon-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_thelounge&repository_url=https%3A%2F%2Fgithub.com%2Fhassio-addons%2Frepository
-[contributors]: https://github.com/hassio-addons/addon-thelounge/graphs/contributors
+[contributors]: https://github.com/hassio-addons/app-thelounge/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
 [forum]: https://community.home-assistant.io/?u=timmo001
-[issue]: https://github.com/hassio-addons/addon-thelounge/issues
+[issue]: https://github.com/hassio-addons/app-thelounge/issues
 [reddit]: https://reddit.com/r/homeassistant
-[releases]: https://github.com/hassio-addons/addon-thelounge/releases
+[releases]: https://github.com/hassio-addons/app-thelounge/releases
 [semver]: https://semver.org/spec/v2.0.0.html
 [themes]: https://www.npmjs.com/search?q=keywords%3Athelounge-theme
 [timmo]: https://github.com/timmo001

--- a/thelounge/Dockerfile
+++ b/thelounge/Dockerfile
@@ -55,10 +55,10 @@ LABEL \
     maintainer="Timmo <contact@timmo.xyz>" \
     org.opencontainers.image.title="${BUILD_NAME}" \
     org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
-    org.opencontainers.image.vendor="Home Assistant Community Add-ons" \
+    org.opencontainers.image.vendor="Home Assistant Community Apps" \
     org.opencontainers.image.authors="Timmo <contact@timmo.xyz>" \
     org.opencontainers.image.licenses="MIT" \
-    org.opencontainers.image.url="https://addons.community" \
+    org.opencontainers.image.url="https://frenck.dev/home-assistant-apps" \
     org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
     org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
     org.opencontainers.image.created=${BUILD_DATE} \

--- a/thelounge/config.yaml
+++ b/thelounge/config.yaml
@@ -3,7 +3,7 @@ name: The Lounge
 version: dev
 slug: thelounge
 description: A self-hosted web IRC client
-url: https://github.com/hassio-addons/addon-thelounge
+url: https://github.com/hassio-addons/app-thelounge
 arch:
   - aarch64
   - amd64

--- a/thelounge/rootfs/etc/nginx/nginx.conf
+++ b/thelounge/rootfs/etc/nginx/nginx.conf
@@ -13,7 +13,7 @@ worker_processes 1;
 # Enables the use of JIT for regular expressions to speed-up their processing.
 pcre_jit on;
 
-# Write error log to the add-on log.
+# Write error log to the app log.
 error_log /proc/1/fd/1 error;
 
 # Max num of simultaneous connections by a worker process.

--- a/thelounge/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/thelounge/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -1,12 +1,12 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 # Configures NGINX for use with thelounge
 # ==============================================================================
 
 # Generate direct access configuration, if enabled.
-if bashio::var.has_value "$(bashio::addon.port 80)"; then
+if bashio::var.has_value "$(bashio::app.port 80)"; then
     bashio::config.require.ssl
     bashio::var.json \
         certfile "$(bashio::config 'certfile')" \

--- a/thelounge/rootfs/etc/s6-overlay/s6-rc.d/init-thelounge/run
+++ b/thelounge/rootfs/etc/s6-overlay/s6-rc.d/init-thelounge/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 # This adds the default user and installs any requested themes
 # ==============================================================================
 declare users

--- a/thelounge/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/thelounge/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 # Take down the S6 supervision tree when Nginx fails
 # ==============================================================================
 exit_code_container=$(</run/s6-linux-init-container-results/exitcode)

--- a/thelounge/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/thelounge/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 # Runs the Nginx daemon
 # ==============================================================================
 

--- a/thelounge/rootfs/etc/s6-overlay/s6-rc.d/thelounge/finish
+++ b/thelounge/rootfs/etc/s6-overlay/s6-rc.d/thelounge/finish
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 # Take down the S6 supervision tree when the server fails
 # ==============================================================================
 exit_code_container=$(</run/s6-linux-init-container-results/exitcode)

--- a/thelounge/rootfs/etc/s6-overlay/s6-rc.d/thelounge/run
+++ b/thelounge/rootfs/etc/s6-overlay/s6-rc.d/thelounge/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: The Lounge
+# Home Assistant Community App: The Lounge
 # Runs The Lounge server
 # ==============================================================================
 export THELOUNGE_HOME=/data/thelounge


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Home Assistant renames add-ons to apps as of the 2026.2 release. This prepares the repository for that change.

> [!IMPORTANT]
> This rewrites repository URLs to `hassio-addons/app-thelounge`, which **does not exist yet**. The repository needs to be renamed from `addon-thelounge` to `app-thelounge` at or before merge, otherwise the badges and links in this pull request will 404.

**Terminology**
"Add-on" and "Add-ons" become "App" and "Apps" throughout, preserving the capitalization already in place at each occurrence. "Home Assistant Community Add-ons" becomes "Home Assistant Community Apps".

**URLs**
Repository URLs move from `addon-thelounge` to `app-thelounge`. The `hassio-addons` organization is deliberately untouched, since changing that would be highly breaking. The image URL label moves from `addons.community` to `frenck.dev/home-assistant-apps`.

**Workflows**
The shared `addon-ci` and `addon-deploy` wrappers are swapped for their `app-ci` and `app-deploy` counterparts, still pinned by digest to v4.0.0.

**Bashio**
`bashio::addon.port` becomes `bashio::app.port`. This is the only change needed for the v0.17.5 to v0.19.0 upgrade. The old name still works through a compatibility shim, but has logged a deprecation warning since v0.18.0. Verified in the built image: the old name warns, the new one does not. Every other bashio function used in this repository still exists unchanged in v0.19.0.

**Deliberately not renamed**
These are machine read values rather than prose, so renaming them would break things:

- `io.hass.type="addon"`, which the Supervisor reads. 26 of the 28 already migrated `app-*` repositories keep this as `addon`.
- The `my.home-assistant.io` `supervisor_addon` service paths and the `?addon=` query parameter.
- The `discord.me/hassioaddons` vanity URL.
- The `[addon]` and `[addon-badge]` markdown link reference names, matching the other migrated repositories.

**Drive-by fixes**
The contribution guidelines pointed at a personal fork that no longer holds this project; they now point at `hassio-addons/app-thelounge`. The screenshot URL in `.README.j2` referenced a `master` branch that does not exist, and now references `main`.

Verified with YAMLLint, Shellcheck, Hadolint, JSON lint, Prettier and a full `docker build`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows #243, which has been merged.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
