### PR TITLE
🚨 Align with the conventions used across the other apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/* @frenck
+.github/** @frenck

--- a/thelounge/DOCS.md
+++ b/thelounge/DOCS.md
@@ -47,6 +47,7 @@ dealing with an unknown issue. Possible values are:
 - `trace`: Show every detail, like all called internal functions.
 - `debug`: Shows detailed debug information.
 - `info`: Normal (usually) interesting events.
+- `notice`: Normal but significant events.
 - `warning`: Exceptional occurrences that are not errors.
 - `error`: Runtime errors that do not require immediate action.
 - `fatal`: Something went terribly wrong. App becomes unusable.

--- a/thelounge/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/thelounge/rootfs/etc/nginx/includes/proxy_params.conf
@@ -5,7 +5,7 @@ proxy_redirect              off;
 proxy_send_timeout          86400s;
 proxy_max_temp_file_size    0;
 
-proxy_set_header Accept-Encoding "gzip";
+proxy_set_header Accept-Encoding "";
 proxy_set_header Connection $connection_upgrade;
 proxy_set_header Host $http_host;
 proxy_set_header Upgrade $http_upgrade;

--- a/thelounge/translations/en.yaml
+++ b/thelounge/translations/en.yaml
@@ -1,0 +1,40 @@
+---
+configuration:
+  log_level:
+    name: Log level
+    description: >-
+      Controls the level of log output by the app and can be changed to be
+      more or less verbose, which might be useful when you are dealing with
+      an unknown issue. Each level automatically includes the messages of a
+      more severe level.
+  ssl:
+    name: SSL
+    description: >-
+      Enables/Disables encrypted SSL (HTTPS) for direct access to the app.
+      This setting has no effect on the Ingress service.
+  certfile:
+    name: Certificate file
+    description: >-
+      The certificate file to use for SSL. The file must be stored in the
+      `/ssl/` directory.
+  keyfile:
+    name: Private key file
+    description: >-
+      The private key file to use for SSL. The file must be stored in the
+      `/ssl/` directory.
+  default_theme:
+    name: Default theme
+    description: >-
+      The theme each user starts out with. Use one of the themes bundled with
+      The Lounge, or one you added using the themes option. Every user can
+      still pick a different theme in their own settings.
+  themes:
+    name: Themes
+    description: >-
+      A list of additional themes to install, using their package name as
+      published on the npm registry.
+  users:
+    name: Users
+    description: >-
+      A list of users to create. Each new user starts out with the default
+      password `hassio`. Make sure to change it right after your first login.


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Housekeeping that brings this app in line with the conventions the other apps already follow. No behaviour depends on any of it, so this is deliberately separate from #245, which carries the actual bug fixes.

**Configuration translations**
Adds `translations/en.yaml`, so the options render with readable names and descriptions in the Home Assistant interface rather than the raw keys. 18 of the 28 other apps already ship one. Verified the file covers every key in the configuration schema, with no missing and no extra entries.

**CODEOWNERS pattern**
`.github/*` becomes `.github/**`. A single asterisk does not cross a slash, so everything under `.github/workflows/` was not actually covered by the ownership rule. The other apps already use the double asterisk form.

**Accept-Encoding towards The Lounge**
The proxy forced `Accept-Encoding: gzip` upstream. Every other app sends an empty value here, and this repository was one of only two doing otherwise. Forcing it is also mildly incorrect: NGINX passes the upstream `Content-Encoding` straight through, so a client that never announced gzip support can still be handed a gzipped body. NGINX has `gzip on` and compresses on its own anyway. Verified `nginx -t` still passes and the image still builds.

**Documentation**
The configuration schema accepts `notice` as a `log_level`, but the documentation listed every level except that one. Now documented, matching the wording used in the other apps.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows the review that also produced #245. Independent of it: both branch from `main` and touch different files, so they can be merged in either order.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
